### PR TITLE
Add github action to check release download

### DIFF
--- a/.github/workflows/test-release-download.yml
+++ b/.github/workflows/test-release-download.yml
@@ -1,0 +1,16 @@
+name: test-release-download
+on:
+  workflow_dispatch:
+
+jobs:
+  download-all-binaries:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: k14s/setup-k14s-action@v1
+      - run: |
+          ytt version
+          kbld version
+          kapp version
+          kwt version
+          imgpkg version
+          vendir version


### PR DESCRIPTION
This new workflow is intended to help with the release of new versions of all the Carvel tools.
Running this workflow would try to check all the binaries and download them to ensure the release notes are correct