### PR TITLE
Rename references to k14s in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We’d love to accept your patches and contributions to this project. Please rev
 
 # Communication
 
-We prefer communicating asynchronously through GitHub issues and the [k14s Slack channel](https://kubernetes.slack.com/archives/CH8KCCKA5). In order to be inclusive to the community, if a conversation related to an issue happens outside of these channels, we appreciate summarizing the conversation's context and adding it to an issue.
+We prefer communicating asynchronously through GitHub issues and the [Carvel Slack channel](https://kubernetes.slack.com/archives/CH8KCCKA5). In order to be inclusive to the community, if a conversation related to an issue happens outside of these channels, we appreciate summarizing the conversation's context and adding it to an issue.
 
 # Propose a Change
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -40,4 +40,4 @@ If you forget, the `check build up to date` build step will fail.
 ## Releasing
 
 1. Publish a release to the Marketplace with a semver name, e.g. `v1.2.3`. (Note: the `v` prefix is important, as are the minor and patch versions. `1.2.3` and `v1.2` aren't valid if you want the automated workflow in #2 to do its thing.)
-2. If this is the latest release per semver naming then the [release workflow](https://github.com/k14s/setup-k14s-action/actions?query=workflow%3Arelease) will automatically update the major tag for the release (e.g. if you release v1.2.3 it will update the `v1` tag to point to the same commit as `v1.2.3`).
+2. If this is the latest release per semver naming then the [release workflow](https://github.com/vmware-tanzu/carvel-setup-action/actions?query=workflow%3Arelease) will automatically update the major tag for the release (e.g. if you release v1.2.3 it will update the `v1` tag to point to the same commit as `v1.2.3`).

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-setup-k14s-action
+carvel-setup-action
 
 Copyright (c) 2019-Present Pivotal Software, Inc. All Rights Reserved.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# setup-k14s-action
+# carvel-setup-action
 
-[![Build Status](https://github.com/k14s/setup-k14s-action/workflows/build/badge.svg?branch=develop)](https://github.com/k14s/setup-k14s-action/actions?query=branch%3Adevelop+workflow%3Abuild)
-[![Release Status](https://github.com/k14s/setup-k14s-action/workflows/release/badge.svg)](https://github.com/k14s/setup-k14s-action/actions?query=workflow%3Arelease)
+[![Build Status](https://github.com/vmware-tanzu/carvel-setup-action/workflows/build/badge.svg?branch=develop)](https://github.com/vmware-tanzu/carvel-setup-action/actions?query=branch%3Adevelop+workflow%3Abuild)
+[![Release Status](https://github.com/vmware-tanzu/carvel-setup-action/workflows/release/badge.svg)](https://github.com/vmware-tanzu/carvel-setup-action/actions?query=workflow%3Arelease)
 
-A [Github Action](https://github.com/features/actions) to install k14s apps (such as ytt, kbld, kapp, etc.)
+A [Github Action](https://github.com/features/actions) to install Carvel apps (such as ytt, kbld, kapp, etc.)
 
 - Slack: [#carvel in Kubernetes slack](https://slack.kubernetes.io)
 
@@ -13,17 +13,17 @@ By default, installs latest versions of `ytt`, `kbld`, `kapp`, `kwt`, `imgpkg` a
 
 ```yaml
 steps:
-- uses: k14s/setup-k14s-action@v1
+- uses: vmware-tanzu/carvel-setup-action@v1
 - run: |
     ytt version
     kbld version
 ```
 
-`setup-k14s-action` uses the GitHub API to find information about latest releases. To avoid [rate limits](https://developer.github.com/v3/#rate-limiting) it is recommended you pass a [token](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token):
+`carvel-setup-action` uses the GitHub API to find information about latest releases. To avoid [rate limits](https://developer.github.com/v3/#rate-limiting) it is recommended you pass a [token](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token):
 
 ```yaml
 steps:
-- uses: k14s/setup-k14s-action@v1
+- uses: vmware-tanzu/carvel-setup-action@v1
   with:
     token: ${{ secrets.GITHUB_TOKEN }}
 - run: |
@@ -35,7 +35,7 @@ To install only specific apps:
 
 ```yaml
 steps:
-- uses: k14s/setup-k14s-action@v1
+- uses: vmware-tanzu/carvel-setup-action@v1
   with:
     only: ytt, kbld
 - run: |
@@ -47,7 +47,7 @@ To use a specific version of an app:
 
 ```yaml
 steps:
-- uses: k14s/setup-k14s-action@v1
+- uses: vmware-tanzu/carvel-setup-action@v1
   with:
     only: ytt, kbld
     kbld: v0.28.0
@@ -58,4 +58,4 @@ steps:
 
 ## Development
 
-See [DEVELOPMENT](https://github.com/k14s/setup-k14s-action/blob/develop/DEVELOPMENT.md).
+See [DEVELOPMENT](https://github.com/vmware-tanzu/carvel-setup-action/blob/develop/DEVELOPMENT.md).

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: setup-k14s-action
-description: Install k14s apps (ytt, kbld, kapp, etc.)
-author: The K14s Authors
+description: Install Carvel apps (ytt, kbld, kapp, etc.)
+author: The Carvel Authors
 branding:
   color: 'green'
   icon: 'play'

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: setup-k14s-action
+name: carvel-setup-action
 description: Install Carvel apps (ytt, kbld, kapp, etc.)
 author: The Carvel Authors
 branding:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "setup-k14s-action",
+  "name": "carvel-setup-action",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "setup-k14s-action",
+  "name": "carvel-setup-action",
   "private": true,
-  "description": "A Github Action to install k14s apps (such as ytt, kbld, kapp, etc.)",
+  "description": "A Github Action to install Carvel apps (such as ytt, kbld, kapp, etc.)",
   "main": "lib/main.js",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
This PR renames all references to k14s in docs, all links to the k14s/setup-k14s-action repo, and renames the action itself to carvel-setup-action.

It does not rename all k14s references in code. I'll refactor those in a subsequent PR.