### PR TITLE
chore: remove prepare script

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,7 +33,7 @@ Before submitting a PR, you need to:
 1. Format your code.
 2. Update `dist/index.js`.
 
-You can do this with `npm run prepare`.
+You can do this with `npm run all`.
 
 If you forget, the `check build up to date` build step will fail.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",
     "pack": "ncc build",
-    "prepare": "npm run format && npm run build && npm run pack",
     "test": "jest",
     "all": "npm run build && npm run format && npm run lint && npm run pack && npm test",
     "verify:installed": "node test/e2e/verify_installed.js",


### PR DESCRIPTION
Doesn't need to be run on `npm install`, and generally has limited use.