### PR TITLE
Update node12 to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,5 +46,5 @@ inputs:
     required: false
     default: latest
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Following [https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

Fixes #242