### PR TITLE
fix: e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,11 +74,11 @@ jobs:
     - uses: ./
       with:
         only: ytt
-        ytt: v0.27.0
+        ytt: v0.43.4
         token: ${{ secrets.GITHUB_TOKEN }}
     - run: npm ci
     - name: check specific version is installed
-      run: npm run verify:output "ytt version" "ytt version 0.27.0"
+      run: npm run verify:output "ytt version" "ytt version 0.43.4"
 
   test-e2e-no-token:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I think there's a bug in https://github.com/jbrunton/gha-installer, which probably needs to implement paging for when there are a lot of releases being returned by the GitHub API. In the meantime, this PR fixes the e2e tests in the build workflow for this action by using a more recent version in the test.